### PR TITLE
Removed back button in list template when set as root

### DIFF
--- a/ios/RNCarPlay.m
+++ b/ios/RNCarPlay.m
@@ -401,6 +401,10 @@ RCT_EXPORT_METHOD(setRootTemplate:(NSString *)templateId animated:(BOOL)animated
             NSLog(@"error %@", err);
             // noop
         }];
+        if ([template isKindOfClass:[CPListTemplate class]]) {
+            CPListTemplate *listTemplate = (CPListTemplate *)template;
+            [listTemplate setBackButton:nil];
+        }
     } else {
         NSLog(@"Failed to find template %@", template);
     }


### PR DESCRIPTION
If a List Template is set as root template, back button is not needed as it does nothing.