### PR TITLE
Fixed multiple pushes of nowPlaying template

### DIFF
--- a/ios/RNCarPlay.m
+++ b/ios/RNCarPlay.m
@@ -428,7 +428,6 @@ RCT_EXPORT_METHOD(pushNowPlaying) {
     CPTemplate *template = [CPNowPlayingTemplate sharedTemplate];
     UIApplication *application = [UIApplication sharedApplication];
 
-    //[store.interfaceController pushTemplate:template animated:YES];
     if([store.interfaceController topTemplate] == template) {
         return;
     }


### PR DESCRIPTION
In pushNowPlaying method, nowPlaying template was pushed before checking if it was pushed before, making the app to crash.