### PR TITLE
Fixin crash when opening carplay

### DIFF
--- a/ios/RNCarPlay.m
+++ b/ios/RNCarPlay.m
@@ -1058,6 +1058,11 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
 
     NSMutableDictionary *body = [[NSMutableDictionary alloc] initWithDictionary:json];
     NSDictionary *userInfo = [template userInfo];
+    
+    if (userInfo == nil) {
+        return;
+    }
+    
     [body setObject:[userInfo objectForKey:@"templateId"] forKey:@"templateId"];
     [self sendEventWithName:name body:body];
 }


### PR DESCRIPTION
Steps of the error:
1. Play something in the phone
2. Connect to CarPlay device. Audio shoud continue in CarPlay 
3. Press "Now playing" in CarPlay device. App crashes
